### PR TITLE
remove master branch push trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - master
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
### Motivation
With our current master branch protection rule any merges into master will already have passed the CI status checks. This will reduce redundant triggers of the CI workflow