### PR TITLE
Fix bug where user requests are not saved on sign-out

### DIFF
--- a/src/utilities/firebase.js
+++ b/src/utilities/firebase.js
@@ -58,7 +58,7 @@ export const signInWithGoogle = async () => {
 
       // Create or update user in the database
       const userRef = ref(database, `users/${user.uid}`);
-      set(userRef, {
+      update(userRef, {
         displayName: user.displayName,
         email: user.email,
         photoURL: user.photoURL,


### PR DESCRIPTION
### Implementation
It turns out that user requests are in fact persisted to Firebase; the bug occurs when the user signs in again, as the sign-in function makes a set call to Firebase that destructively overwrites all existing requests. The solution is to just use the non-destructive update function